### PR TITLE
adds autolabeler for github

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+XML:
+- changed-files:
+  - any-glob-to-any-file:
+    - .xml/**
+
+python:
+- changed-files:
+  - any-glob-to-any-file:
+    - .py/**
+
+documentation:
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/**
+    - README.md**
+    - LICENSE**
+
+PNG:
+- changed-files:
+  - any-glob-to-any-file:
+    - .png/**

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
adds an autolabeler workflow that adds labels to PRs depending on what type of file they edit.

current labels are Python, XML, PNG, and Documentation